### PR TITLE
增加扫码登录缓存cookie功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/qrcode-terminal": "^0.12.2",
     "NeteaseCloudMusicApi": "^4.13.6",
     "debug": "^4.3.4",
     "delay": "^6.0.0",
@@ -56,6 +57,7 @@
     "picocolors": "^1.0.0",
     "promise.map": "^0.5.0",
     "promise.retry": "^1.1.1",
+    "qrcode-terminal": "^0.12.0",
     "rc": "^1.2.8",
     "react": "^18.2.0",
     "update-notifier": "^7.0.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,7 @@
 import { COOKIE_CONTENT } from '$auth/cookie'
 import { baseDebug } from '$common'
 import { Album, DjradioProgram, Playlist, SongData, SongPlayUrlInfo } from '$define'
-import Api, { login_qr_check } from 'NeteaseCloudMusicApi'
+import Api from 'NeteaseCloudMusicApi'
 import qrcode from 'qrcode-terminal' // 不能 import { xxx } from 'qrcode-terminal'，运行会出错，一个bug
 import delay from 'delay'
 import { chunk } from 'lodash-es'

--- a/src/auth/cookie.ts
+++ b/src/auth/cookie.ts
@@ -1,7 +1,11 @@
 import { existsSync, readFileSync } from 'fs'
-import { resolve } from 'path'
+import { resolve, join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
-export const DEFAULT_COOKIE_FILE = 'yun.cookie.txt'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export const DEFAULT_COOKIE_FILE = join(__dirname, 'yun.cookie.txt')
 
 export let COOKIE_CONTENT: string | undefined = undefined
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -131,7 +131,7 @@ const parser = yargs(hideBin(process.argv))
     'login',
     '登录账号缓存 cookie 文件',
     (yargs) => {
-      // 放弃在这折腾，所有子命令的执行在 $login.ts
+      // 放弃在这折腾，所有子命令的执行在 $cmd/login.ts
       // 在这里写存在线程竞争的问题
       return (
         yargs

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { DEFAULT_COOKIE_FILE, readCookie } from '$auth/cookie'
+import { DEFAULT_COOKIE_FILE } from '$auth/cookie'
 import createEsmUtils from 'esm-utils'
 import rcFactory from 'rc'
 import { PackageJson } from 'type-fest'

--- a/src/cmd/login.ts
+++ b/src/cmd/login.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_COOKIE_FILE } from '$auth/cookie'
+import { QRCodeLogin } from '$api'
+import { existsSync, unlink, writeFile } from 'fs'
+
+export function loginCommand(args: string[]) {
+  if (args.length == 1) {
+    if (existsSync(DEFAULT_COOKIE_FILE)) {
+      console.log('本地已经缓存了 cookie 文件，若要覆盖，请执行 `yun login delete` 进行删除。') // 如果在 yargs .command 里的函数，这里的 yun 可替换为 $0
+      process.exit(1)
+    } else {
+      QRCodeLogin().then((cookie) => {
+        writeFile(DEFAULT_COOKIE_FILE, cookie, (err) => {
+          if (err) {
+            console.log(`写入 cookie 文件[${DEFAULT_COOKIE_FILE}]错误，内容:\n${cookie}`)
+          } else {
+            console.log('cookie 缓存成功')
+          }
+          process.exit(0)
+        })
+      })
+    }
+  } else {
+    switch (args[1]) {
+      case 'check': {
+        checkCookie()
+        break
+      }
+      case 'delete': {
+        try {
+          deleteCookie()
+        } catch (e) {
+          console.error(e)
+          process.exit(1)
+        }
+        break
+      }
+    }
+    process.exit(0)
+  }
+}
+
+function checkCookie() {
+  if (existsSync(DEFAULT_COOKIE_FILE)) {
+    console.log('本地已经缓存了 cookie 文件')
+  } else {
+    console.log('没有缓存 cookie 文件，请使用 `yun login` 命令缓存')
+  }
+}
+
+function deleteCookie() {
+  unlink(DEFAULT_COOKIE_FILE, (err) => {
+    if (err) {
+      throw new Error(`无法删除 [${DEFAULT_COOKIE_FILE}]，请手动删除。`)
+    } else {
+      console.log('删除本地缓存 cookie 成功')
+    }
+  })
+}

--- a/src/cmd/yun.ts
+++ b/src/cmd/yun.ts
@@ -1,0 +1,134 @@
+import { SongValid } from '$define'
+import { downloadSong, getAdapter, getFileName } from '$index'
+import { baseDebug } from '$common'
+import { dl } from 'dl-vampire'
+import filenamify from 'filenamify'
+import humanizeDuration from 'humanize-duration'
+import { padStart } from 'lodash-es'
+import logSymbols from 'log-symbols'
+import ms from 'ms'
+import path from 'path'
+import pmap from 'promise.map'
+import { readCookie } from '$auth/cookie'
+
+const debug = baseDebug.extend('cli')
+
+export type ExpectedArgv = {
+  url: string
+  concurrency: number
+  format: string
+  quality: number
+  retryTimeout: number
+  retryTimes: number
+  skip: boolean
+  progress: boolean
+  cover: boolean
+  cookie: string
+}
+
+export async function main(argv) {
+  let {
+    url,
+    concurrency,
+    format,
+    quality,
+    retryTimeout,
+    retryTimes,
+    skip: skipExists,
+    progress,
+    cover,
+  } = argv
+
+  // 打印
+  console.log(`
+	当前参数
+	concurrency:    ${concurrency}
+	format:         ${format}
+	retry-timeout:  ${retryTimeout} (分钟)
+	retry-times:    ${retryTimes} (次)
+	quality:        ${quality}k
+	skip:           ${skipExists}
+	progress:       ${progress}
+	cover:          ${cover}
+	`)
+
+  // process argv
+  quality *= 1000
+  retryTimeout = ms(`${retryTimeout} minutes`) as number
+  readCookie(argv.cookie)
+
+  // only id as url provided
+  if (url && /^\d+$/.test(url)) {
+    url = `https://music.163.com/#/playlist?id=${url}`
+  }
+
+  const start = Date.now()
+  const adapter = getAdapter(url)
+
+  // 基本信息
+  const name = await adapter.getTitle()
+  console.log(`正在下载『${name}』,请稍候...`)
+
+  // 封面
+  if (cover) {
+    const coverUrl = await adapter.getCover()
+    if (!coverUrl) {
+      console.log(`${logSymbols.warning} [cover]: 没有找到封面`)
+    } else {
+      const coverExt = path.extname(coverUrl) || '.jpg'
+      const coverFile = `${filenamify(name)}/cover${coverExt}`
+      await dl({ url: coverUrl, file: coverFile })
+      console.log(`${logSymbols.success} [cover]: 封面已下载 ${coverFile}`)
+    }
+  }
+
+  const songs = await adapter.getSongs(quality)
+  debug('songs : %j', songs)
+
+  const removed = songs.filter((x) => !x.url)
+  const keeped = songs.filter((x) => x.url) as SongValid[]
+
+  if (removed.length) {
+    console.log(`${logSymbols.warning} [版权受限] 不可下载 ${removed.length}/${songs.length}`)
+    for (let i of removed) {
+      console.log(`  ${i.singer} - ${i.songName}`)
+    }
+  }
+
+  // FIXME
+  // process.exit()
+
+  // 开始下载
+  console.log(`${logSymbols.info} 可下载 ${keeped.length}/${songs.length} 首`)
+
+  // fix index
+  const len = keeped.length.toString().length
+  keeped.forEach((item, index) => {
+    item.rawIndex = index // rawIndex: 0,1 ...
+    item.index = padStart(String(index + 1), len, '0') // index, first as 01
+  })
+
+  await pmap(
+    keeped,
+    (song) => {
+      // 文件名
+      const file = getFileName({ format: format, song: song, url: url, name: name })
+      // 下载
+      return downloadSong({
+        url: song.url,
+        file,
+        song,
+        totalLength: keeped.length,
+        retryTimeout,
+        retryTimes,
+        skipExists,
+        progress,
+      })
+    },
+    concurrency
+  )
+
+  const dur = humanizeDuration(Date.now() - start, { language: 'zh_CN' })
+  console.log('下载完成, 耗时%s', dur)
+  process.exit(0)
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,3 +27,10 @@ export const getId = function (url: string) {
   const id = u.searchParams.get('id')
   return id
 }
+
+/**
+ * 线程堵塞
+ */
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
- 由于rc在文档中没有明确的说明除unix意外的平台配置路径具体是什么，所以采用了当前方案，将cookie存放在程序目录（`__dirname`）。之后 --cookie 在未指定的情况下不再是 `yun.cookie.txt`，而是 `__dirname/yun.cookie.txt`。
- 需要用到线程堵塞，所以将 bin.ts 中参数解析后的代码封装到一个函数中。包括 yargs 执行子命令的时候顺序很难弄清楚。