### PR TITLE
修复下载同名的不同歌曲时会发生的覆盖问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
+import os from 'node:os'
 import path from 'node:path'
 import { dl } from 'dl-vampire'
 import filenamify from 'filenamify'
+import fs from 'fs-extra'
 import logSymbols from 'log-symbols'
 import type { Song } from '$define'
 import { AlbumAdapter } from './adapter/album'
@@ -63,14 +65,26 @@ export function downloadSong(options: DownloadSongOptions & { progress?: boolean
   }
 }
 
+// 移除判重数据
+export function removeFileNameFromTracker(filePath: string, size: number | null) {
+  if (!size) return
+  const baseKey = getBaseNameWithoutNumbering(path.basename(filePath, path.extname(filePath))).toLocaleLowerCase('en')
+  const sizes = generatedFileNames.get(baseKey)
+  if (sizes) {
+    sizes.delete(size)
+    if (sizes.size === 0) generatedFileNames.delete(baseKey)
+  }
+}
+
 export async function downloadSongPlain(options: DownloadSongOptions) {
   const { url, file, song, totalLength, retryTimeout, retryTimes, skipExists, skipTrial } = options
-
+  const expectedSize =
+    song.raw && song.raw.playUrlInfo && song.raw.playUrlInfo.size ? Number(song.raw.playUrlInfo.size) : null
   if (song.isFreeTrial && skipTrial) {
     console.log(`${logSymbols.warning} ${song.index}/${totalLength} 跳过试听 ${file}`)
+    removeFileNameFromTracker(file, expectedSize)
     return
   }
-
   let skip = false
   try {
     ;({ skip } = await dl({
@@ -88,10 +102,11 @@ export async function downloadSongPlain(options: DownloadSongOptions) {
   } catch (e: any) {
     console.log(`${logSymbols.error} ${song.index}/${totalLength} 下载失败 ${file}`)
     console.error(e.stack || e)
+    removeFileNameFromTracker(file, expectedSize)
     return
   }
-
   console.log(`${logSymbols.success} ${song.index}/${totalLength} ${skip ? '下载跳过' : '下载成功'} ${file}`)
+  removeFileNameFromTracker(file, expectedSize)
 }
 
 /**
@@ -118,6 +133,112 @@ export function getAdapter(url: string) {
   return new adapter(url)
 }
 
+// 用于跟踪已分配的文件名及其大小，避免重名和内容重复
+const generatedFileNames: Map<string, Set<number>> = new Map()
+
+export function resetFileNameTracker() {
+  generatedFileNames.clear()
+}
+
+function getBaseNameWithoutNumbering(filename: string) {
+  const ext = path.extname(filename)
+  let base = path.basename(filename, ext)
+  base = base.replace(/ \(\d+\)$/, '')
+  return base
+}
+
+function fileExistsCaseInsensitiveWithSizeCheck(filePath: string, expectedSize: number | null): boolean {
+  const dir = path.dirname(filePath)
+  const targetBase = getBaseNameWithoutNumbering(path.basename(filePath)).toLocaleLowerCase('en')
+  try {
+    const files = fs.readdirSync(dir)
+    for (const f of files) {
+      if (getBaseNameWithoutNumbering(f).toLocaleLowerCase('en') === targetBase) {
+        const abs = path.join(dir, f)
+        try {
+          const stat = fs.statSync(abs)
+          if (expectedSize && stat.size === expectedSize) {
+            return true
+          }
+        } catch {}
+      }
+    }
+  } catch {}
+  return false
+}
+
+function handleDuplicateFileName(filePath: string, expectedSize: number | null): string | typeof SKIP_DOWNLOAD {
+  const isWin = os.platform() === 'win32'
+  const dir = path.dirname(filePath)
+  const ext = path.extname(filePath)
+  const base = path.basename(filePath, ext)
+  let counter = 0
+  let newPath: string
+  while (true) {
+    newPath = counter === 0 ? path.join(dir, `${base}${ext}`) : path.join(dir, `${base} (${counter})${ext}`)
+    // 检查本地和进程内是否有同“本名+大小”文件，若有则直接跳过
+    let skip = false
+    // 本地判重
+    if (isWin) {
+      try {
+        if (fs.existsSync(newPath)) {
+          let stat: fs.Stats | undefined
+          try {
+            stat = fs.statSync(newPath)
+          } catch {}
+          if (expectedSize && stat && stat.size === expectedSize) {
+            skip = true
+          }
+        }
+      } catch {}
+    } else {
+      try {
+        if (fs.existsSync(newPath)) {
+          let stat: fs.Stats | undefined
+          try {
+            stat = fs.statSync(newPath)
+          } catch {}
+          if (expectedSize && stat && stat.size === expectedSize) {
+            skip = true
+          }
+        }
+      } catch {}
+    }
+    // 进程内判重
+    const baseKey = getBaseNameWithoutNumbering(path.basename(newPath, ext)).toLocaleLowerCase('en')
+    const sizes = generatedFileNames.get(baseKey)
+    if (!skip && sizes && expectedSize && sizes.has(expectedSize)) {
+      skip = true
+    }
+    if (skip) {
+      return SKIP_DOWNLOAD
+    }
+    // 只判定当前 newPath 是否被本地或进程内占用
+    let localExists = false
+    try {
+      localExists = fs.existsSync(newPath)
+    } catch {
+      localExists = false
+    }
+    let memExists = false
+    if (sizes && expectedSize && sizes.has(expectedSize)) {
+      memExists = true
+    }
+    if (!localExists && !memExists) {
+      // 记录到进程内Map
+      if (expectedSize) {
+        if (!generatedFileNames.has(baseKey)) generatedFileNames.set(baseKey, new Set())
+        generatedFileNames.get(baseKey)!.add(expectedSize)
+      }
+      return newPath
+    }
+    counter++
+  }
+}
+
+// 跳过下载的特殊标记
+export const SKIP_DOWNLOAD = Symbol('SKIP_DOWNLOAD')
+
 /**
  * 获取歌曲文件表示
  */
@@ -125,13 +246,14 @@ export function getFileName({
   format,
   song,
   url,
-  // 专辑 or playlist 名称
   name,
+  checkSkipExists = true,
 }: {
   format: string
   song: Song
   url: string
   name: string
+  checkSkipExists?: boolean
 }) {
   const adapterItem = getType(url)
 
@@ -173,5 +295,42 @@ export function getFileName({
     format = path.join(dir, `${base} [试听]${ext}`)
   }
 
-  return format
+  // 检查本名+大小是否已存在，若是则跳过下载，否则始终走 handleDuplicateFileName
+  if (checkSkipExists) {
+    try {
+      const absPath = path.resolve(format)
+      const isWin = os.platform() === 'win32'
+      const expectedSize =
+        song.raw && song.raw.playUrlInfo && song.raw.playUrlInfo.size ? Number(song.raw.playUrlInfo.size) : null
+      let skip = false
+      if (isWin) {
+        skip = fileExistsCaseInsensitiveWithSizeCheck(absPath, expectedSize)
+      } else if (fs.existsSync(absPath)) {
+        let stat: fs.Stats | undefined
+        try {
+          stat = fs.statSync(absPath)
+        } catch {}
+        if (expectedSize && stat && stat.size === expectedSize) {
+          skip = true
+        }
+      }
+      // 检查当前进程内已分配的文件名（generatedFileNames Map）
+      if (!skip && expectedSize) {
+        const targetBase = getBaseNameWithoutNumbering(path.basename(absPath)).toLocaleLowerCase('en')
+        const sizes = generatedFileNames.get(targetBase)
+        if (sizes && sizes.has(expectedSize)) {
+          skip = true
+        }
+      }
+      if (skip) {
+        return SKIP_DOWNLOAD
+      }
+    } catch {
+      // ignore
+    }
+  }
+  // 只要没跳过，始终走 handleDuplicateFileName，确保同名不同大小的文件自动编号
+  const expectedSize =
+    song.raw && song.raw.playUrlInfo && song.raw.playUrlInfo.size ? Number(song.raw.playUrlInfo.size) : null
+  return handleDuplicateFileName(format, expectedSize)
 }

--- a/test/debug-filename.test.ts
+++ b/test/debug-filename.test.ts
@@ -1,0 +1,45 @@
+import path from 'node:path'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getFileName, resetFileNameTracker } from '../src/index'
+import type { Song } from '../src/define'
+
+describe('Debug filename generation', () => {
+  beforeEach(() => {
+    resetFileNameTracker()
+  })
+
+  it('should debug filename generation', () => {
+    const format = ':name/:songName.:ext'
+    const url = 'https://music.163.com/#/playlist?id=123'
+    const name = 'Test Playlist'
+
+    const song1: Song = {
+      singer: 'Artist A',
+      songName: 'Same Song',
+      albumName: 'Album 1',
+      index: '01',
+      rawIndex: 0,
+      ext: 'mp3',
+    }
+
+    const song2: Song = {
+      singer: 'Artist B',
+      songName: 'Same Song',
+      albumName: 'Album 2',
+      index: '02',
+      rawIndex: 1,
+      ext: 'mp3',
+    }
+
+    const filename1 = getFileName({ format, song: song1, url, name })
+    const filename2 = getFileName({ format, song: song2, url, name })
+
+    console.log('Filename 1:', filename1)
+    console.log('Filename 2:', filename2)
+
+    // 使用 path.normalize 来处理路径分隔符
+
+    expect(path.normalize(filename1 as string)).toBe(path.normalize('Test Playlist/Same Song.mp3'))
+    expect(path.normalize(filename2 as string)).toBe(path.normalize('Test Playlist/Same Song (1).mp3'))
+  })
+})


### PR DESCRIPTION
## 问题描述

  本人下载某东方歌单时，508首只下载到396个文件。经过检查发现如果出现同名不同大小的歌曲，原程序会直接下载，导致这些歌曲在文件系统的管理下相互覆盖，产生数据丢失。

## 解决方式

  添加了同名检测逻辑，如果同名会在末尾加上序号，如果歌曲的本名和大小与已有文件或正在下载的其他文件相同，程序仍然会跳过下载